### PR TITLE
fix(reddit): support min-version font hook shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.1-dev.1](https://github.com/ch3thanhs/stylus/compare/v1.0.0...v1.0.1-dev.1) (2026-07-19)
+
+### 🐛 Bug Fixes
+
+* **reddit:** support min-version font hook shape ([5aca099](https://github.com/ch3thanhs/stylus/commit/5aca099cfe1ca9ae0c69753d31c8f339875d5176))
+
 ## 1.0.0 (2026-07-17)
 
 ### ✨ New Features

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of font related [Morphe](https://morphe.software) patches.
 ## 🩹 Patches list
 
 <!-- PATCHES_START EXPANDED -->
-> **[v1.0.0](https://github.com/ch3thanhs/stylus/releases/tag/v1.0.0)**&nbsp;&nbsp;•&nbsp;&nbsp;`main`&nbsp;&nbsp;•&nbsp;&nbsp;2 patches total
+> **[v1.0.1-dev.1](https://github.com/ch3thanhs/stylus/releases/tag/v1.0.1-dev.1)**&nbsp;&nbsp;•&nbsp;&nbsp;`dev`&nbsp;&nbsp;•&nbsp;&nbsp;2 patches total
 <details open>
 <summary>📦 Reddit&nbsp;&nbsp;•&nbsp;&nbsp;2 patches</summary>
 <br>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel = true
 org.gradle.caching = true
 kotlin.code.style = official
-version = 1.0.0
+version = 1.0.1-dev.1

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-17T16:25:39",
-  "description": "## 1.0.0 (2026-07-17)\n\n### ✨ New Features\n\n* initial patches release ([98ecf42](https://github.com/ch3thanhs/stylus/commit/98ecf42cf53795e2553d4cce10a2834bd1e894a4))",
-  "download_url": "https://github.com/ch3thanhs/stylus/releases/download/v1.0.0/patches-1.0.0.mpp",
+  "created_at": "2026-07-19T14:30:44",
+  "description": "## [1.0.1-dev.1](https://github.com/ch3thanhs/stylus/compare/v1.0.0...v1.0.1-dev.1) (2026-07-19)\n\n### 🐛 Bug Fixes\n\n* **reddit:** support min-version font hook shape ([5aca099](https://github.com/ch3thanhs/stylus/commit/5aca099cfe1ca9ae0c69753d31c8f339875d5176))",
+  "download_url": "https://github.com/ch3thanhs/stylus/releases/download/v1.0.1-dev.1/patches-1.0.1-dev.1.mpp",
   "signature_download_url": "",
-  "version": "1.0.0"
+  "version": "1.0.1-dev.1"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.0.0",
+  "version": "1.0.1-dev.1",
   "patches": [
     {
       "name": "Custom font",

--- a/patches/src/main/kotlin/app/stylus/patches/reddit/font/CustomFontPatch.kt
+++ b/patches/src/main/kotlin/app/stylus/patches/reddit/font/CustomFontPatch.kt
@@ -90,24 +90,32 @@ val customFontPatch = bytecodePatch(
     customFontFileOption()
 
     execute {
-        // TypefaceCompat.createFromResourcesFontFile is the central choke point that
-        // returns a Typeface for every R.font.* lookup made by AndroidX (and therefore
-        // by Compose's FontFamily resolver and View's font attribute).
-        // Param mapping for this static method:
-        //   p0 = Resources, p1 = font res id, p2 = path (e.g. reddit_sans_semi_bold.ttf),
-        //   p3 = ttc index, p4 = style (Typeface.NORMAL / BOLD / ITALIC / BOLD_ITALIC).
-        // p2 is forwarded so the extension can recover the requested weight from the
-        // original font's file name and select that weight from the custom variable font.
-        TypefaceCompatCreateFromResourcesFontFileFingerprint.method.addInstructionsWithLabels(
+        val targetMethod = resolveTypefaceCompatCreateFromResourcesFontFileTarget()
+
+        // Param mapping changes between legacy and modern method shapes.
+        targetMethod.method.addInstructionsWithLabels(
             0,
-            """
-                invoke-static { p0, p2, p4 }, $EXTENSION_CLASS->getCustomTypeface(Landroid/content/res/Resources;Ljava/lang/String;I)Landroid/graphics/Typeface;
-                move-result-object v0
-                if-eqz v0, :original
-                return-object v0
-                :original
-                nop
-            """
+            when (targetMethod.variant) {
+                TypefaceCompatCreateFromResourcesFontFileVariant.LEGACY_STATIC ->
+                    """
+                        invoke-static { p0, p2, p4 }, $EXTENSION_CLASS->getCustomTypeface(Landroid/content/res/Resources;Ljava/lang/String;I)Landroid/graphics/Typeface;
+                        move-result-object v0
+                        if-eqz v0, :original
+                        return-object v0
+                        :original
+                        nop
+                    """
+
+                TypefaceCompatCreateFromResourcesFontFileVariant.MODERN_VIRTUAL ->
+                    """
+                        invoke-static { p2, p4, p5 }, $EXTENSION_CLASS->getCustomTypeface(Landroid/content/res/Resources;Ljava/lang/String;I)Landroid/graphics/Typeface;
+                        move-result-object v0
+                        if-eqz v0, :original
+                        return-object v0
+                        :original
+                        nop
+                    """
+            }
         )
     }
 }

--- a/patches/src/main/kotlin/app/stylus/patches/reddit/font/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/stylus/patches/reddit/font/Fingerprints.kt
@@ -2,6 +2,7 @@ package app.stylus.patches.reddit.font
 
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.methodCall
+import app.morphe.patcher.patch.BytecodePatchContext
 import com.android.tools.smali.dexlib2.AccessFlags
 
 /**
@@ -16,7 +17,17 @@ import com.android.tools.smali.dexlib2.AccessFlags
  * plus the unique direct call to `Font.Builder.<init>(Resources, int)`,
  * which only this resource-loading variant performs.
  */
-internal object TypefaceCompatCreateFromResourcesFontFileFingerprint : Fingerprint(
+internal enum class TypefaceCompatCreateFromResourcesFontFileVariant {
+    LEGACY_STATIC,
+    MODERN_VIRTUAL,
+}
+
+internal data class TypefaceCompatCreateFromResourcesFontFileTarget(
+    val variant: TypefaceCompatCreateFromResourcesFontFileVariant,
+    val method: app.morphe.patcher.util.proxy.mutableTypes.MutableMethod,
+)
+
+internal object LegacyTypefaceCompatCreateFromResourcesFontFileFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
     returnType = "Landroid/graphics/Typeface;",
     parameters = listOf(
@@ -30,3 +41,34 @@ internal object TypefaceCompatCreateFromResourcesFontFileFingerprint : Fingerpri
         methodCall(smali = "Landroid/graphics/fonts/Font${'$'}Builder;-><init>(Landroid/content/res/Resources;I)V"),
     ),
 )
+
+internal object ModernTypefaceCompatCreateFromResourcesFontFileFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "Landroid/graphics/Typeface;",
+    parameters = listOf(
+        "Landroid/content/Context;",
+        "Landroid/content/res/Resources;",
+        "I",
+        "Ljava/lang/String;",
+        "I",
+    ),
+    filters = listOf(
+        methodCall(smali = "Landroid/graphics/fonts/Font${'$'}Builder;-><init>(Landroid/content/res/Resources;I)V"),
+    ),
+)
+
+context(_: BytecodePatchContext)
+internal fun resolveTypefaceCompatCreateFromResourcesFontFileTarget(): TypefaceCompatCreateFromResourcesFontFileTarget {
+    listOf(
+        TypefaceCompatCreateFromResourcesFontFileVariant.LEGACY_STATIC to LegacyTypefaceCompatCreateFromResourcesFontFileFingerprint,
+        TypefaceCompatCreateFromResourcesFontFileVariant.MODERN_VIRTUAL to ModernTypefaceCompatCreateFromResourcesFontFileFingerprint,
+    ).forEach { (variant, fingerprint) ->
+        try {
+            return TypefaceCompatCreateFromResourcesFontFileTarget(variant, fingerprint.method)
+        } catch (_: Throwable) {
+            // Try the next method shape.
+        }
+    }
+
+    throw IllegalStateException("Failed to match any typeface creation method shape")
+}

--- a/patches/src/main/kotlin/app/stylus/patches/reddit/font/ForceSystemFontPatch.kt
+++ b/patches/src/main/kotlin/app/stylus/patches/reddit/font/ForceSystemFontPatch.kt
@@ -18,22 +18,32 @@ val forceSystemFontPatch = bytecodePatch(
     extendWith("extensions/extension.mpe")
 
     execute {
-        // TypefaceCompat.createFromResourcesFontFile is the central choke point that
-        // returns a Typeface for every R.font.* lookup made by AndroidX (and therefore
-        // by Compose's FontFamily resolver and View's font attribute).
-        // Param mapping for this static method:
-        //   p0 = Resources, p1 = font res id, p2 = path,
-        //   p3 = ttc index, p4 = style (Typeface.NORMAL / BOLD / ITALIC / BOLD_ITALIC).
-        TypefaceCompatCreateFromResourcesFontFileFingerprint.method.addInstructionsWithLabels(
+        val targetMethod = resolveTypefaceCompatCreateFromResourcesFontFileTarget()
+
+        // Param mapping changes between legacy and modern method shapes.
+        targetMethod.method.addInstructionsWithLabels(
             0,
-            """
-                invoke-static { p4 }, $EXTENSION_CLASS->getSystemTypeface(I)Landroid/graphics/Typeface;
-                move-result-object v0
-                if-eqz v0, :original
-                return-object v0
-                :original
-                nop
-            """
+            when (targetMethod.variant) {
+                TypefaceCompatCreateFromResourcesFontFileVariant.LEGACY_STATIC ->
+                    """
+                        invoke-static { p4 }, $EXTENSION_CLASS->getSystemTypeface(I)Landroid/graphics/Typeface;
+                        move-result-object v0
+                        if-eqz v0, :original
+                        return-object v0
+                        :original
+                        nop
+                    """
+
+                TypefaceCompatCreateFromResourcesFontFileVariant.MODERN_VIRTUAL ->
+                    """
+                        invoke-static { p5 }, $EXTENSION_CLASS->getSystemTypeface(I)Landroid/graphics/Typeface;
+                        move-result-object v0
+                        if-eqz v0, :original
+                        return-object v0
+                        :original
+                        nop
+                    """
+            }
         )
     }
 }


### PR DESCRIPTION
Ports the Reddit font min-version compatibility fix to Stylus dev so font hooks work across both legacy and modern Reddit method shapes.